### PR TITLE
v1.2 RemoveCommand Feature 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RemoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveCommand.java
@@ -12,6 +12,9 @@ import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 
+/**
+ * Removes a contact identified based on matching name and further confirmation of removal with index.
+ */
 public class RemoveCommand extends Command{
 
     public static final String COMMAND_WORD = "remove";

--- a/src/main/java/seedu/address/logic/commands/RemoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveCommand.java
@@ -1,0 +1,121 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+
+public class RemoveCommand extends Command{
+
+    public static final String COMMAND_WORD = "remove";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Remove the person identified by the matching name in the contacts list.\n"
+            + "Parameters: EXISTING_CONTACT_NAME\n"
+            + "Example: " + COMMAND_WORD + " John Doe";
+
+    public static final String MESSAGE_PERSONS_TO_REMOVE_NOT_FOUND = "No contacts found with the given name!";
+    public static final String MESSAGE_PERSONS_TO_REMOVE_FOUND = "%1$d contact(s) found with the given name. "
+            + "Please specify the index of the contact to remove.\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_REMOVE_PERSON_SUCCESS = "Removed Contact: %1$s";
+
+    private final NameContainsKeywordsPredicate predicate;
+
+    private final Index targetIndex;
+
+    /**
+     * Constructs the first RemoveCommand with the given predicate.
+     * @param predicate Keyword to filter out the contacts that match the given name, for safe deletion.
+     */
+    public RemoveCommand(NameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+        this.targetIndex = null;
+    }
+
+    /**
+     * Constructs the second RemoveCommand with the given index.
+     * @param targetIndex Index of the contact to be removed.
+     */
+    public RemoveCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+        this.predicate = null;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        // First constructor is called, 1st part of RemoveCommand function - finding the contact for safe removal
+        if (predicate != null && targetIndex == null) {
+            model.updateFilteredPersonList(predicate);
+            // if no matching names found
+            if (model.getFilteredPersonList().size() == 0) {
+                throw new CommandException(MESSAGE_PERSONS_TO_REMOVE_NOT_FOUND);
+            } else {
+                return new CommandResult(
+                        String.format(MESSAGE_PERSONS_TO_REMOVE_FOUND, model.getFilteredPersonList().size()));
+            }
+        } else if (targetIndex != null && predicate == null) {
+            // Second constructor is called, 2nd part of RemoveCommand function - actual removal of contact
+            // Index called has to refer to the filtered list from part 1
+            List<Person> lastShownList = model.getFilteredPersonList();
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+            Person personToRemove = lastShownList.get(targetIndex.getZeroBased());
+            model.deletePerson(personToRemove);
+            return new CommandResult(String.format(MESSAGE_REMOVE_PERSON_SUCCESS, Messages.format(personToRemove)));
+        } else {
+            // Should not reach here 
+            throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_FORMAT);
+        }
+
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RemoveCommand)) {
+            return false;
+        }
+
+        RemoveCommand otherRemoveCommand = (RemoveCommand) other;
+
+        if (predicate != null && targetIndex == null) {
+            return predicate.equals(otherRemoveCommand.predicate);
+        } else{
+            assert targetIndex != null;
+            return targetIndex.equals(otherRemoveCommand.targetIndex);
+        }
+    }
+
+    @Override
+    public String toString() {
+
+        if (predicate != null && targetIndex == null) {
+            return new ToStringBuilder(this)
+                    .add("predicate", predicate)
+                    .toString();
+        } else {
+            return new ToStringBuilder(this)
+                    .add("targetIndex", targetIndex)
+                    .toString();
+        }
+
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/RemoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveCommand.java
@@ -75,7 +75,7 @@ public class RemoveCommand extends Command{
             model.deletePerson(personToRemove);
             return new CommandResult(String.format(MESSAGE_REMOVE_PERSON_SUCCESS, Messages.format(personToRemove)));
         } else {
-            // Should not reach here 
+            // Should not reach here
             throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_FORMAT);
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.RemoveCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -61,6 +62,9 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case RemoveCommand.COMMAND_WORD:
+            return new RemoveCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/RemoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveCommandParser.java
@@ -8,8 +8,17 @@ import java.util.Arrays;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+/**
+ * Parses input arguments and creates a new RemoveCommand object
+ */
 public class RemoveCommandParser {
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the RemoveCommand
+     * and returns a RemoveCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public RemoveCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
@@ -26,6 +35,9 @@ public class RemoveCommandParser {
         }
     }
 
+    /**
+     * Returns true if the string is an integer.
+     */
     private boolean isInteger(String str) {
         try {
             Integer.parseInt(str);

--- a/src/main/java/seedu/address/logic/parser/RemoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveCommandParser.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.RemoveCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+import java.util.Arrays;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+public class RemoveCommandParser {
+
+    public RemoveCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveCommand.MESSAGE_USAGE));
+        }
+
+        String[] identifiers = trimmedArgs.split("\\s+");
+
+        if (identifiers.length == 1 && isInteger(identifiers[0])) {
+            return new RemoveCommand(ParserUtil.parseIndex(identifiers[0]));
+        } else {
+            return new RemoveCommand(new NameContainsKeywordsPredicate(Arrays.asList(identifiers)));
+        }
+    }
+
+    private boolean isInteger(String str) {
+        try {
+            Integer.parseInt(str);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The current Delete Command is inconvenient as it requires users to find the index of the contact to delete, which is unscalable when the address book expands. It is also unsafe, as there are no intermediate steps to confirm the deletion.

The logic of (1) `remove <NAME>`, then listing an intermediate filtered list of contacts with matching names, before (2) `remove <INDEX>` from the much shorter list of matching contacts, is used.

Entering the name of the contact to remove is preferable over directly using the index in large address books, where finding the index might be inconvenient.

Presenting a shorter list of contacts with names matching the predicate given in (1) then allows the index in (2) to be found more conveniently, and serves as an intermediate step to help users confirm their deletion.