### PR TITLE
Add Input Navigation using Up/Down Keys

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -4,9 +4,13 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.Region;
+import javafx.scene.input.KeyEvent;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+
+
+import java.util.ArrayList;
 
 /**
  * The UI component that is responsible for receiving user command inputs.
@@ -15,8 +19,11 @@ public class CommandBox extends UiPart<Region> {
 
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
+    private static final int ZERO_INDEX = 0;
 
     private final CommandExecutor commandExecutor;
+
+    private InputHistory inputHistory;
 
     @FXML
     private TextField commandTextField;
@@ -27,6 +34,7 @@ public class CommandBox extends UiPart<Region> {
     public CommandBox(CommandExecutor commandExecutor) {
         super(FXML);
         this.commandExecutor = commandExecutor;
+        this.inputHistory = new InputHistory();
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
     }
@@ -46,6 +54,26 @@ public class CommandBox extends UiPart<Region> {
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+        } finally {
+            System.out.println(inputHistory.count);
+            inputHistory.addToInputHistory(commandText);
+            commandTextField.setText("");
+        }
+    }
+
+    /**
+     * Handles the Up/Down key pressed event.
+     * @param event The event when a key is pressed.
+     */
+    @FXML
+    private void handleArrowKey(KeyEvent event) {
+        if (event.getCode().getName().equals("Up")) {
+            inputHistory.decrementCount();
+            commandTextField.setText(inputHistory.getCommand());
+        }
+        if (event.getCode().getName().equals("Down")) {
+            inputHistory.incrementCount();
+            commandTextField.setText(inputHistory.getCommand());
         }
     }
 
@@ -80,6 +108,38 @@ public class CommandBox extends UiPart<Region> {
          * @see seedu.address.logic.Logic#execute(String)
          */
         CommandResult execute(String commandText) throws CommandException, ParseException;
+    }
+
+    public class InputHistory {
+        ArrayList<String> inputList;
+        int count;
+
+        public InputHistory() {
+            this.inputList = new ArrayList<>();
+            this.count = ZERO_INDEX;
+        }
+
+        public void addToInputHistory(String commandText) {
+            this.inputList.add(commandText);
+            this.count++;
+        }
+        public void incrementCount() {
+            int maxListIndex = inputList.size() - 1;
+            if (this.count < maxListIndex) {
+                this.count++;
+            }
+        }
+
+        public void decrementCount() {
+            if (this.count != ZERO_INDEX) {
+                this.count--;
+            }
+        }
+
+        public String getCommand() {
+            return this.inputList.get(count);
+        }
+
     }
 
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,12 +1,14 @@
 package seedu.address.ui;
 
 import java.util.ArrayList;
+import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -19,6 +21,7 @@ public class CommandBox extends UiPart<Region> {
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
     private static final int ZERO_INDEX = 0;
+    private static final Logger logger = LogsCenter.getLogger(CommandBox.class);
 
     private final CommandExecutor commandExecutor;
 
@@ -150,6 +153,7 @@ public class CommandBox extends UiPart<Region> {
 
             if (this.currentIndex < maxListIndex) {
                 this.currentIndex++;
+                logger.info("Showing succeeding command.");
             }
         }
 
@@ -159,6 +163,7 @@ public class CommandBox extends UiPart<Region> {
         public void decrementIndex() {
             if (this.currentIndex != ZERO_INDEX) {
                 this.currentIndex--;
+                logger.info("Showing previous command.");
             }
         }
 

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -67,12 +67,20 @@ public class CommandBox extends UiPart<Region> {
     private void handleArrowKey(KeyEvent event) {
         if (event.getCode().getName().equals("Up")) {
             inputHistory.decrementIndex();
-            commandTextField.setText(inputHistory.getCommand());
+            setTextField();
         }
         if (event.getCode().getName().equals("Down")) {
             inputHistory.incrementIndex();
-            commandTextField.setText(inputHistory.getCommand());
+            setTextField();
         }
+    }
+
+    /**
+     * Sets the text field with the command, moves caret to the end of text.
+     */
+    private void setTextField() {
+        commandTextField.setText(inputHistory.getCommand());
+        commandTextField.end();
     }
 
     /**

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -65,11 +65,12 @@ public class CommandBox extends UiPart<Region> {
      */
     @FXML
     private void handleArrowKey(KeyEvent event) {
-        if (event.getCode().getName().equals("Up")) {
+        String keyName = event.getCode().getName();
+        if (keyName.equals("Up")) {
             inputHistory.decrementIndex();
             setTextField();
         }
-        if (event.getCode().getName().equals("Down")) {
+        if (keyName.equals("Down")) {
             inputHistory.incrementIndex();
             setTextField();
         }
@@ -79,7 +80,8 @@ public class CommandBox extends UiPart<Region> {
      * Sets the text field with the command, moves caret to the end of text.
      */
     private void setTextField() {
-        commandTextField.setText(inputHistory.getCommand());
+        String commandText = inputHistory.getCommand();
+        commandTextField.setText(commandText);
         commandTextField.end();
     }
 
@@ -137,7 +139,7 @@ public class CommandBox extends UiPart<Region> {
          */
         public void addToInputHistory(String commandText) {
             this.inputList.add(commandText);
-            this.currentIndex++;
+            currentIndex = inputList.size();
         }
 
         /**
@@ -145,6 +147,7 @@ public class CommandBox extends UiPart<Region> {
          */
         public void incrementIndex() {
             int maxListIndex = inputList.size() - 1;
+
             if (this.currentIndex < maxListIndex) {
                 this.currentIndex++;
             }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,16 +1,15 @@
 package seedu.address.ui;
 
+import java.util.ArrayList;
+
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
-import javafx.scene.layout.Region;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-
-import java.util.ArrayList;
 
 /**
  * The UI component that is responsible for receiving user command inputs.
@@ -55,7 +54,7 @@ public class CommandBox extends UiPart<Region> {
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         } finally {
-            System.out.println(inputHistory.count);
+            System.out.println(inputHistory.currentIndex);
             inputHistory.addToInputHistory(commandText);
             commandTextField.setText("");
         }
@@ -68,11 +67,11 @@ public class CommandBox extends UiPart<Region> {
     @FXML
     private void handleArrowKey(KeyEvent event) {
         if (event.getCode().getName().equals("Up")) {
-            inputHistory.decrementCount();
+            inputHistory.decrementIndex();
             commandTextField.setText(inputHistory.getCommand());
         }
         if (event.getCode().getName().equals("Down")) {
-            inputHistory.incrementCount();
+            inputHistory.incrementIndex();
             commandTextField.setText(inputHistory.getCommand());
         }
     }
@@ -110,34 +109,55 @@ public class CommandBox extends UiPart<Region> {
         CommandResult execute(String commandText) throws CommandException, ParseException;
     }
 
+    /**
+     * Encapsulates the input history of typed commands.
+     */
     public class InputHistory {
-        ArrayList<String> inputList;
-        int count;
+        private ArrayList<String> inputList;
+        private int currentIndex;
 
+        /**
+         * Constructor for InputHistory.
+         */
         public InputHistory() {
             this.inputList = new ArrayList<>();
-            this.count = ZERO_INDEX;
+            this.currentIndex = ZERO_INDEX;
         }
 
+        /**
+         * Adds typed in command into inputList.
+         * @param commandText Sting of command.
+         */
         public void addToInputHistory(String commandText) {
             this.inputList.add(commandText);
-            this.count++;
+            this.currentIndex++;
         }
-        public void incrementCount() {
+
+        /**
+         * Increments the counter.
+         */
+        public void incrementIndex() {
             int maxListIndex = inputList.size() - 1;
-            if (this.count < maxListIndex) {
-                this.count++;
+            if (this.currentIndex < maxListIndex) {
+                this.currentIndex++;
             }
         }
 
-        public void decrementCount() {
-            if (this.count != ZERO_INDEX) {
-                this.count--;
+        /**
+         * Decrements the counter.
+         */
+        public void decrementIndex() {
+            if (this.currentIndex != ZERO_INDEX) {
+                this.currentIndex--;
             }
         }
 
+        /**
+         * Retrieves the command corresponding to the counter.
+         * @return String of command.
+         */
         public String getCommand() {
-            return this.inputList.get(count);
+            return this.inputList.get(currentIndex);
         }
 
     }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -54,7 +54,6 @@ public class CommandBox extends UiPart<Region> {
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         } finally {
-            System.out.println(inputHistory.currentIndex);
             inputHistory.addToInputHistory(commandText);
             commandTextField.setText("");
         }

--- a/src/main/java/seedu/address/ui/ExitWindow.java
+++ b/src/main/java/seedu/address/ui/ExitWindow.java
@@ -62,7 +62,7 @@ public class ExitWindow extends UiPart<Stage> {
      *     </ul>
      */
     public void show() {
-        logger.fine("Showing exit confirmation.");
+        logger.fine("Showing exit window.");
         getRoot().show();
         getRoot().centerOnScreen();
     }
@@ -96,6 +96,7 @@ public class ExitWindow extends UiPart<Stage> {
     @FXML
     private void noButton() {
         getRoot().hide();
+        logger.fine("Hiding exit window.");
         yesButton.requestFocus();
     }
 }

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 
-<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
+<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..." onKeyPressed="#handleArrowKey" />
 </StackPane>
-

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.StackPane?>
 
 <StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
   <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..." onKeyPressed="#handleArrowKey" />


### PR DESCRIPTION
Add Input Navigation using Up/Down Keys (Issue #61)

Previously, the command text field only provides users to type in commands, with no addition feature.

With this change, users would now be able to use the Up arrow key to restore a previously typed in command (if there exist a preceding command), regardless of validity.

The Down arrow key also serves to allow users to navigate to the next command, if there exist a succeeding command .

This change brings about better QOL for users using the address book.

Of note, whenever a command is ENTERED, the text field will be cleared.