### PR TITLE
Fix Copy Command Error Message Bug

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
@@ -4,8 +4,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CopyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 
 /**
@@ -19,6 +22,10 @@ public class CopyCommandParser implements Parser<CopyCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public CopyCommand parse(String args) throws ParseException {
+
+        if (args.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE));
+        }
         String[] argsList = args.trim().split(" ");
         Index index = ParserUtil.parseIndex(argsList[0]);
 

--- a/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
@@ -1,14 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CopyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 
 
 /**


### PR DESCRIPTION
Fix copy command not displaying correct message when entering
'copy' in the text field.

Previously, the error message shown was 'Index is not a non-zero
unsigned integer', which is wrong, and does not inform the user of 
the problem. User would not have known that the copy command 
is supposed to be used as `copy INDEX`.

After fix, it shows the user how to correctly use the command.

