### PR TITLE
Add sequence diagram for input history

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -936,6 +936,10 @@ How the `InputHistory` index-pointer works:
 
 - During a Down key press, the index-pointer is incremented by one (i.e. it is point towards a later command in the history).
 
+Below is a sequence diagram when an **Up key** is pressed:
+
+<puml src="diagrams/InputHistorySequenceDiagram.puml" alt="UpKeySequenceDiagram"/>
+
 #### Design Considerations
 - Single Responsibility Principle 
   - `CommandBox` and `InputHistory` are gathered together as the two classes share the responsibilities of receiving and retrieving user inputs within the text field, hence increasing the overall cohesion of Ui components.

--- a/docs/diagrams/InputHistorySequenceDiagram.puml
+++ b/docs/diagrams/InputHistorySequenceDiagram.puml
@@ -1,0 +1,47 @@
+@startuml
+!include style.puml
+skinparam ArrowFontStyle plain
+
+box Ui UI_COLOR_T1
+participant ":CommandBox" as CommandBox UI_COLOR
+participant ":InputHistory" as InputHistory UI_COLOR
+participant ":TextField" as TextField UI_COLOR_T4
+
+end box
+
+
+
+[-> CommandBox : handleArrowKey(upKeyPress)
+activate CommandBox
+
+CommandBox -> InputHistory : decrementIndex()
+activate InputHistory
+
+InputHistory --> CommandBox
+deactivate InputHistory
+
+
+CommandBox -> CommandBox : setTextField()
+activate CommandBox
+
+CommandBox -> InputHistory : getCommand()
+activate InputHistory
+
+InputHistory --> CommandBox : string
+deactivate InputHistory
+
+CommandBox -> TextField : setText(string)
+activate TextField
+
+TextField --> CommandBox
+deactivate TextField
+
+CommandBox --> CommandBox
+deactivate CommandBox
+
+[<--CommandBox
+deactivate CommandBox
+
+
+
+@enduml


### PR DESCRIPTION
Added sequence diagram for InputHistory to be used in DG.

Closes #189 